### PR TITLE
Adding support for warnings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter
 
 
 class Ameba(Linter):
-    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): E: (?P<message>.+)$')
+    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>W)): (?P<message>.+)$')
     multiline = False
 
     tempfile_suffix = '-'


### PR DESCRIPTION
This PR adds supports for _warnings_ too, changing the linter's `regex` to use [named capture groups `error` and `warning`](http://www.sublimelinter.com/en/stable/linter_attributes.html#regex-mandatory).

![Screen Shot 2019-10-05 at 1 04 05 PM](https://user-images.githubusercontent.com/3471751/66257536-e6708d00-e770-11e9-862c-00eaffb21078.png)
