### PR TITLE
Update travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
+
 python:
-  - "3.3"
+  - "3.6"
+
 install:
   - pip install flake8
+
 script:
   - flake8 . --max-line-length=120


### PR DESCRIPTION
Python 3.3 was not found when trying to run the Travis Pipeline

Updating to Python 3.6