### PR TITLE
Support updates to ameba

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter
 
 
 class Ameba(Linter):
-    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>.)): (?P<message>.+)$')
+    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>W|C)): (?P<message>.+)$')
     multiline = False
 
     tempfile_suffix = '-'

--- a/linter.py
+++ b/linter.py
@@ -2,16 +2,20 @@ from SublimeLinter.lint import Linter
 
 
 class Ameba(Linter):
-    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>W|C)): (?P<message>.+)$')
+    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>.)): (?P<message>.+)$')
     multiline = False
 
     tempfile_suffix = '-'
 
     defaults = {
         'selector': 'source.crystal',
+        'auto_fix': false,
         'executable': '${folder}/bin/ameba'
     }
 
     def cmd(self):
         settings = self.get_view_settings()
-        return (settings['executable'], '--format', 'flycheck', '${file}')
+        if settings['auto_fix']:
+            return (settings['executable'], '--format', 'flycheck', '--fix', '${file}')
+        else:
+            return (settings['executable'], '--format', 'flycheck', '${file}')

--- a/linter.py
+++ b/linter.py
@@ -9,7 +9,7 @@ class Ameba(Linter):
 
     defaults = {
         'selector': 'source.crystal',
-        'auto_fix': false,
+        'auto_fix': False,
         'executable': '${folder}/bin/ameba'
     }
 

--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter
 
 
 class Ameba(Linter):
-    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>W)): (?P<message>.+)$')
+    regex = (r'^.+:(?P<line>\d+):(?P<col>\d+): ((?P<error>E)|(?P<warning>W|C)): (?P<message>.+)$')
     multiline = False
 
     tempfile_suffix = '-'


### PR DESCRIPTION
At some point ameba was updated to support correctable errors and uses a `C` for the type of message. Rather than swallow unknown message types, will keep `E` for error and anything else (`W`, `C`, etc.) as warnings.

Ameba now supports the `--fix` option to fix said correctable problems, so added a setting to `auto_fix` these options.

Apologies if I messed up the linter at all, this is my first time modifying a Sublime Linter, or even a Sublime Plugin :)