### PR TITLE
Make it easier to work on the crystal language syntax for Sublime Text

### DIFF
--- a/disable_for_syntax_checks.py
+++ b/disable_for_syntax_checks.py
@@ -1,0 +1,7 @@
+import os
+
+class MaybeDisableSublimeLinterAmeba(sublime_plugin.EventListener):
+    def on_loaded(self, view):
+        if os.path.basename(window.active_view().file_name()).startswith("syntax_test_"):
+            view.settings().set("SublimeLinter.linters.contrib-ameba.disable", True)
+


### PR DESCRIPTION
A minor thing, but in working on the Crystal syntax (https://github.com/crystal-lang-tools/sublime-crystal/pull/77) it was difficult to prevent ameba from complaining about the syntax tests--rightfully so, as it's passed the file directly so the `.ameba.yml` cannot prevent it.

This little bit of code fixes that, only for files starting with `syntax_check_`.

Shouldn't have any effect on anyone/anything else.
